### PR TITLE
ACodec: Fix video autoscaling on old OMX decoders

### DIFF
--- a/media/libstagefright/ACodec.cpp
+++ b/media/libstagefright/ACodec.cpp
@@ -8046,6 +8046,15 @@ bool ACodec::OutputPortSettingsChangedState::onOMXEvent(
                     return false;
                 }
 
+#ifdef USE_LEGACY_RESCALING
+                // Resolution is about to change
+                // Make sure the decoder knows
+                sp<AMessage> reply = new AMessage(kWhatOutputBufferDrained, mCodec);
+                mCodec->onOutputFormatChanged();
+                mCodec->addKeyFormatChangesToRenderBufferNotification(reply);
+                mCodec->sendFormatChange();
+#endif
+
                 ALOGV("[%s] Output port now reenabled.", mCodec->mComponentName.c_str());
 
                 if (mCodec->mExecutingState->active()) {
@@ -8059,6 +8068,15 @@ bool ACodec::OutputPortSettingsChangedState::onOMXEvent(
 
             return false;
         }
+
+#ifdef USE_LEGACY_RESCALING
+        case OMX_EventPortSettingsChanged:
+            // Exynos OMX wants to share its' output crop
+            // For some reason trying to handle this here doesn't do anything
+            // We'll do it right before transitioning to ExecutingState
+            return true;
+        break;
+#endif
 
         default:
             return false;

--- a/media/libstagefright/Android.mk
+++ b/media/libstagefright/Android.mk
@@ -161,6 +161,10 @@ LOCAL_CFLAGS += -DCAMCORDER_GRALLOC_SOURCE
 endif
 endif
 
+ifeq ($(TARGET_OMX_LEGACY_RESCALING),true)
+LOCAL_CFLAGS += -DUSE_LEGACY_RESCALING
+endif
+
 LOCAL_CFLAGS += -Wno-multichar -Werror -Wno-error=deprecated-declarations -Wall
 
 LOCAL_C_INCLUDES += $(call project-path-for,qcom-media)/mm-core/inc


### PR DESCRIPTION
To enable: TARGET_OMX_LEGACY_RESCALING := true

On Android N video autoscaling will cause the video to zoom in, being mostly outside of the frame of the video.
This is because android no longer tries to match output ports before putting the new resolution in effect.
Exynos OMX decoders send a message to get the new output crop, but it's lost along the way.
Similarly to how Android M handles it, send the format change right before transitioning to ExecutingState.

Patch Set 2