### PR TITLE
DO NOT MERGE Add fmq function instantiations to preserve ABI

### DIFF
--- a/media/bufferpool/2.0/BufferStatus.cpp
+++ b/media/bufferpool/2.0/BufferStatus.cpp
@@ -21,6 +21,21 @@
 #include <time.h>
 #include "BufferStatus.h"
 
+// This is added to preserve ABI for b/184963385
+template bool android::hardware::MessageQueue<
+    android::hardware::media::bufferpool::V2_0::BufferStatusMessage,
+    android::hardware::kSynchronizedReadWrite>::
+    write(
+        const android::hardware::media::bufferpool::V2_0::BufferStatusMessage *,
+        size_t count);
+#ifndef __aarch64__
+template bool android::hardware::MessageQueue<
+    android::hardware::media::bufferpool::V2_0::BufferInvalidationMessage,
+    android::hardware::kUnsynchronizedWrite>::
+    write(const android::hardware::media::bufferpool::V2_0::
+              BufferInvalidationMessage *,
+          size_t count);
+#endif
 namespace android {
 namespace hardware {
 namespace media {


### PR DESCRIPTION
Bug: 184963385
Test: check abidiff after full build
Test: out/soong/.intermediates/frameworks/av/media/bufferpool/2.0/libstagefright_bufferpool@2.0/android_arm_armv8-a_vendor_shared/libstagefright_bufferpool@2.0.so.abidiff
Change-Id: I25b7180bb88b4bace4a1d9ad5a789d79cbe3de35
(cherry picked from commit b0e09634903a73908b84361564215a79f1f6bdb1)